### PR TITLE
Added training/cora.py to load the Cora dataset, updated training/cit…

### DIFF
--- a/tests/test_cora.py
+++ b/tests/test_cora.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path so `training` package imports work during tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Provide lightweight fake modules for heavy dependencies so importing the module
+# doesn't require torch/torch_geometric to be installed during tests.
+import types
+
+fake_torch = types.ModuleType("torch")
+sys.modules["torch"] = fake_torch
+
+tg = types.ModuleType("torch_geometric")
+tg_datasets = types.ModuleType("torch_geometric.datasets")
+tg_transforms = types.ModuleType("torch_geometric.transforms")
+
+def _fake_Planetoid(root, name, transform=None):
+    # This will be overridden in the actual test via monkeypatch, but provide a
+    # default placeholder to satisfy imports.
+    return None
+
+tg_datasets.Planetoid = _fake_Planetoid
+tg_transforms.NormalizeFeatures = lambda: None
+
+sys.modules["torch_geometric"] = tg
+sys.modules["torch_geometric.datasets"] = tg_datasets
+sys.modules["torch_geometric.transforms"] = tg_transforms
+
+import pytest
+
+from training import cora
+
+
+class DummyDataset:
+    def __init__(self, root, name, transform):
+        self.root = root
+        self.name = name
+        self.transform = transform
+        self.num_classes = 3
+
+    def __getitem__(self, idx):
+        return {"x": "node_features", "edge_index": "edges", "y": 0}
+
+    def __len__(self):
+        return 1
+
+
+def test_load_cora_monkeypatched(monkeypatch):
+    """Ensure load_cora returns dataset[0] and num_classes when Planetoid is patched."""
+
+    def fake_Planetoid(root, name, transform):
+        return DummyDataset(root, name, transform)
+
+    monkeypatch.setattr(cora, "Planetoid", fake_Planetoid)
+
+    data, num_classes = cora.load_cora()
+
+    assert isinstance(data, dict)
+    assert data["x"] == "node_features"
+    assert data["edge_index"] == "edges"
+    assert data["y"] == 0
+    assert num_classes == 3

--- a/training/cora.py
+++ b/training/cora.py
@@ -4,9 +4,9 @@ from torch_geometric.datasets import Planetoid
 from torch_geometric.transforms import NormalizeFeatures
 
 # Function to load the citeseer dataset and return the graph data and number of classes.
-def load_citeseer():
-    # Load the citeseer dataset using PyTorch Geometric's Planetoid class.
-    dataset = Planetoid(root='datasets/Citeseer', name='Citeseer', transform=NormalizeFeatures())
+def load_cora():
+    # Load the cora dataset using PyTorch Geometric's Planetoid class.
+    dataset = Planetoid(root='datasets/Cora', name='Cora', transform=NormalizeFeatures())
     data = dataset[0]  # Get the graph data object from the dataset.
     
     return data, dataset.num_classes  # Return the graph data and the number of classes for classification.


### PR DESCRIPTION
Resolves #5 

Features:
- training/cora.py Python script to load the Cora dataset for use in the training scripts to be implemented.
- Added a unit test for training/cora.py
- Adjusted the root directory of the dataset in citeseer.py

Limitation:
- This commit does not split the Cora dataset into the training / test / validation splits. This will be done in issue #9 and issue #10.